### PR TITLE
Skip creating file/directory when it errors.

### DIFF
--- a/main.go
+++ b/main.go
@@ -107,16 +107,16 @@ func (n *nodeLabelsToFiles) parseFlags() error {
 }
 
 func Exists(name string) bool {
-    if _, err := os.Stat(name); err != nil {
-        if os.IsNotExist(err) {
-            return false
-        }
-    }
-    return true
+	if _, err := os.Stat(name); err != nil {
+		if os.IsNotExist(err) {
+			return false
+		}
+	}
+	return true
 }
 
 func (n *nodeLabelsToFiles) getConfig() (*rest.Config, error) {
-	if n.config.kubeconfig == "" || !Exists(n.config.kubeconfig) { 
+	if n.config.kubeconfig == "" || !Exists(n.config.kubeconfig) {
 		return rest.InClusterConfig()
 	}
 	return clientcmd.BuildConfigFromFlags("", n.config.kubeconfig)
@@ -175,15 +175,15 @@ func (n *nodeLabelsToFiles) deleteStaleFiles(labels map[string]string) error {
 	return nil
 }
 
-func (n *nodeLabelsToFiles) createFileFromLabels(labels map[string]string) error {
+func (n *nodeLabelsToFiles) createFileFromLabels(labels map[string]string) {
 	for fileName, fileContent := range labels {
 		err := writeToFile(filepath.Join(n.config.directory, fileName),
 			fileContent)
+		klog.V(5).Infof("Creating file: %s, with content: %s", fileName, fileContent)
 		if err != nil {
-			return err
+			klog.Errorf("Failed creating file: %s, due to: %s", fileName, err)
 		}
 	}
-	return nil
 }
 
 func writeToFile(fileName string, fileContent string) error {
@@ -222,11 +222,8 @@ func (n *nodeLabelsToFiles) processOnce(labels map[string]string) {
 	klog.V(2).Info("Refreshing Labels information for: ", n.config.nodeName)
 	klog.V(2).Infof("Retrieved labels: %v for node: %s", labels,
 		n.config.nodeName)
-	err := n.createFileFromLabels(labels)
-	if err != nil {
-		klog.Fatalf("Encountered: %s, while trying to create files from "+
-			"labels: %v", err, labels)
-	}
+	n.createFileFromLabels(labels)
+	var err error
 	if n.config.deleteStaleFiles {
 		err = n.deleteStaleFiles(labels)
 	} else {

--- a/main_test.go
+++ b/main_test.go
@@ -71,7 +71,7 @@ func TestCreateFileFromLabels(t *testing.T) {
 	labels := map[string]string{
 		"arch": "amd64",
 		"failure-domain.beta.kubernetes.io/region": "us-east"}
-	err = n.createFileFromLabels(labels)
+	n.createFileFromLabels(labels)
 	if err != nil {
 		t.Error(err)
 	}
@@ -85,6 +85,34 @@ func TestCreateFileFromLabels(t *testing.T) {
 		if expectedContent != actualContent {
 			t.Errorf("Expected: %s, got: %s", expectedContent, actualContent)
 		}
+	}
+}
+
+func TestCreateFileSkipsFiles(t *testing.T) {
+	n := &nodeLabelsToFiles{config: &config{}}
+	dir, err := ioutil.TempDir("", "nodeLabelsToFiles-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+	n.config.directory = dir
+	fileName := "node-role.kubernetes.io"
+	expectedContent := "worker"
+	labels := map[string]string{fileName: expectedContent}
+	n.createFileFromLabels(labels)
+	labels = map[string]string{"node-role.kubernetes.io/node": "selinux-disabled:true"}
+	n.createFileFromLabels(labels)
+	if err != nil {
+		t.Error(err)
+	}
+	actualContent, err := readFromFile(filepath.Join(n.config.directory,
+		fileName))
+	if err != nil {
+		t.Error(err)
+	}
+
+	if expectedContent != actualContent {
+		t.Errorf("Expected: %s, got: %s", expectedContent, actualContent)
 	}
 }
 


### PR DESCRIPTION
Prior to this commit, we error when a directory or file cannot be
created, which could be because a label's name matches both a top level
key, e.g:

```
node-role.kubernetes.io:worker
node-role.kubernetes.io/node: selinux-disabled:true
```

The above labels would have caused the node-labels-to-files to crash,
this just makes it log the error rather than crash.